### PR TITLE
Add 1GB swap file configuration

### DIFF
--- a/server-setup.sh
+++ b/server-setup.sh
@@ -2,6 +2,9 @@
 #Prepares server to host multiple sites. Does not actually add the site.
 #Running this multiple times should be entirely safe (though would be a waste of bandwidth and time, and should be avoided)
 
+#Setup Swap - Essential for low memory servers
+bash setup-swap.sh
+
 #Install Docker
 sudo apt-get update
 sudo apt-get install -y ca-certificates curl gnupg lsb-release

--- a/setup-swap.sh
+++ b/setup-swap.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Checks for swap file and creates one if it doesn't exist.
+# This helps prevent out-of-memory errors during build processes on low-memory servers.
+
+SWAPFILE=/swapfile
+
+if [ -f "$SWAPFILE" ]; then
+    echo "Swap file $SWAPFILE already exists."
+else
+    echo "Creating 1GB swap file at $SWAPFILE..."
+    # fallocate is faster than dd
+    sudo fallocate -l 1G $SWAPFILE || sudo dd if=/dev/zero of=$SWAPFILE bs=1M count=1024
+
+    sudo chmod 600 $SWAPFILE
+    sudo mkswap $SWAPFILE
+    sudo swapon $SWAPFILE
+    echo "Swap file created and enabled."
+
+    # Add to fstab to persist across reboots
+    if ! grep -q "$SWAPFILE" /etc/fstab; then
+        echo "$SWAPFILE none swap sw 0 0" | sudo tee -a /etc/fstab
+        echo "Added to /etc/fstab."
+    fi
+fi
+
+# Display current swap status
+echo "Current swap status:"
+sudo swapon --show
+free -h


### PR DESCRIPTION
This PR introduces a `setup-swap.sh` script to automatically configure a 1GB swap file on the server. This is necessary to prevent out-of-memory errors during the `npm install` and build process on low-memory (1GB) instances, such as the one used for production deployment. The `server-setup.sh` script has been updated to call this new script.

---
*PR created automatically by Jules for task [4086612299334911204](https://jules.google.com/task/4086612299334911204) started by @ecc521*