### PR TITLE
Implement log rotation for server logs

### DIFF
--- a/server/gauges.js
+++ b/server/gauges.js
@@ -16,7 +16,7 @@ try {
 }
 catch(e) {
 	console.error(e)
-	fs.appendFileSync(path.join(utils.getLogDirectory(), "virtualGaugeError.log"), e.toString() + "\n")
+	utils.appendLog("virtualGaugeError.log", e.toString() + "\n")
 }
 
 let readingsFile = path.join(utils.getSiteRoot(), "gaugeReadings")

--- a/server/sendEmails.js
+++ b/server/sendEmails.js
@@ -55,11 +55,11 @@ async function sendEmail(user) {
 	await new Promise((resolve, reject) => {
 		transporter.sendMail(mailOptions, function (err, info) {
 		   if(err) {
-				fs.appendFileSync(path.join(utils.getLogDirectory(), 'emailnotificationserrors.log'), JSON.stringify(err) + "\n");
+				utils.appendLog('emailnotificationserrors.log', JSON.stringify(err) + "\n");
 			   resolve(false)
 		   }
 		   else {
-				fs.appendFileSync(path.join(utils.getLogDirectory(), 'emailnotifications.log'), JSON.stringify(info) + "\n");
+				utils.appendLog('emailnotifications.log', JSON.stringify(info) + "\n");
 			   resolve(info)
 		   }
 		});

--- a/server/utils.js
+++ b/server/utils.js
@@ -64,6 +64,27 @@ function getFilesInDirectory (dir, files_){
     return files_;
 }
 
+function appendLog(filename, data, maxSize = 5 * 1024 * 1024) {
+	let logDir = getLogDirectory()
+	let logPath = path.join(logDir, filename)
+
+	try {
+		if (fs.existsSync(logPath)) {
+			let stats = fs.statSync(logPath)
+			if (stats.size > maxSize) {
+				let oldLogPath = logPath + ".old"
+				if (fs.existsSync(oldLogPath)) {
+					fs.unlinkSync(oldLogPath)
+				}
+				fs.renameSync(logPath, oldLogPath)
+			}
+		}
+		fs.appendFileSync(logPath, data)
+	} catch (e) {
+		console.error("Error writing to log file:", e)
+	}
+}
+
 
 //Gets the body of a request.
 		function getData(request) {
@@ -83,5 +104,6 @@ module.exports = {
 	getLogDirectory,
 	getDataDirectory,
 	getFilesInDirectory,
-	getData
+	getData,
+	appendLog
 }


### PR DESCRIPTION
This PR addresses the issue of unbounded log files on the server.
It introduces a simple log rotation mechanism in `server/utils.js` via the `appendLog` function.
When a log file exceeds 5MB, it is renamed to `.old` (overwriting any existing `.old` file) and a new log file is started.

The following files were updated to use this new logging function:
- `server/gauges.js`: virtualGaugeError.log
- `server/sendEmails.js`: emailnotifications.log, emailnotificationserrors.log

---
*PR created automatically by Jules for task [3996107781000721545](https://jules.google.com/task/3996107781000721545) started by @ecc521*