### PR TITLE
🔒 Fix XSS vulnerability in dangerouslySetInnerHTML via strict DOMPurify wrapper

### DIFF
--- a/src/components/RiverExpansion.tsx
+++ b/src/components/RiverExpansion.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import type { RiverData } from "../types/River";
 import { USGSGraphs } from "./USGSGraphs";
 import { useDynamicFlow } from "../hooks/useDynamicFlow";
-import DOMPurify from "dompurify";
+import { sanitizeHtml } from "../utils/sanitizeHtml";
 import { SharedMap } from "./SharedMap";
 
 interface RiverExpansionProps {
@@ -34,7 +34,7 @@ export const RiverExpansion: React.FC<RiverExpansionProps> = ({ river, isMapOver
     <div className="riverWriteup" style={{ padding: "6px" }}>
 
       <div className="textInfo">
-        <div dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(river.writeup || "", { FORBID_ATTR: ["style"] }) }} />
+        <div dangerouslySetInnerHTML={{ __html: sanitizeHtml(river.writeup || "") }} />
         <br />
 
         {river.averagegradient && (

--- a/src/components/RiverHistoryComparison.tsx
+++ b/src/components/RiverHistoryComparison.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { RiverData } from '../types/River';
-import DOMPurify from 'dompurify';
+import { sanitizeHtml } from '../utils/sanitizeHtml';
 
 interface RiverHistoryComparisonProps {
   historicalState: RiverData;
@@ -56,7 +56,7 @@ export const RiverHistoryComparison: React.FC<RiverHistoryComparisonProps> = ({
       return <span>Unit: {val.unit}, Range: {val.min ?? '?'} - {val.max ?? '?'}</span>;
     }
     if (field === 'writeup') {
-        return <div style={{ maxHeight: '100px', overflowY: 'auto', fontSize: '0.9rem', border: '1px solid var(--border)', padding: '5px' }} dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(val || "", { FORBID_ATTR: ["style"] }) }} />;
+        return <div style={{ maxHeight: '100px', overflowY: 'auto', fontSize: '0.9rem', border: '1px solid var(--border)', padding: '5px' }} dangerouslySetInnerHTML={{ __html: sanitizeHtml(val || "") }} />;
     }
     return <span>{String(val)}</span>;
   };

--- a/src/pages/RiverEditor.tsx
+++ b/src/pages/RiverEditor.tsx
@@ -4,7 +4,7 @@ import { fetchAPI } from "../services/api";
 import ReactQuill from "react-quill-new";
 import "react-quill-new/dist/quill.snow.css"; 
 import { useAuth } from "../context/AuthContext";
-import DOMPurify from "dompurify";
+import { sanitizeHtml } from "../utils/sanitizeHtml";
 import { firebaseConfig } from "../firebase";
 import { skillLevels, getSkillAbbreviation, getSkillIndex } from "../utils/skillTranslations";
 import { RiverItem } from "../components/RiverItem";
@@ -280,7 +280,7 @@ export default function RiverEditor() {
         gauges: parsedGauges,
         tags: (riverData.rawTags || "").split(',').map((t: string) => t.trim()).filter(Boolean),
         accessPoints: newAccessPoints,
-        writeup: DOMPurify.sanitize(riverData.writeup || "", { FORBID_ATTR: ["style"] }),
+        writeup: sanitizeHtml(riverData.writeup || ""),
         flow: riverData.flow || { unit: "cfs", min: null, low: null, mid: null, high: null, max: null },
         updatedAt: Date.now(),
         submittedBy: isReviewMode ? (proposedData?.submittedBy || user?.uid || "anonymous") : (user?.uid || "anonymous"),

--- a/src/utils/sanitizeHtml.ts
+++ b/src/utils/sanitizeHtml.ts
@@ -1,0 +1,24 @@
+import DOMPurify from "dompurify";
+
+// Force all target blank links to have noopener noreferrer to prevent reverse tabnapping
+DOMPurify.addHook("afterSanitizeAttributes", function (node) {
+  if (node.tagName === "A") {
+    // If it's a link, we ensure it opens in a new tab securely to keep users in the app
+    node.setAttribute("target", "_blank");
+    node.setAttribute("rel", "noopener noreferrer");
+  }
+});
+
+/**
+ * Sanitizes an HTML string to prevent XSS attacks.
+ * Uses DOMPurify with strict settings, stripping inline styles.
+ */
+export function sanitizeHtml(html: string): string {
+  if (!html) return "";
+
+  return DOMPurify.sanitize(html, {
+    USE_PROFILES: { html: true },
+    FORBID_ATTR: ["style"],
+    FORBID_TAGS: ["style"],
+  });
+}


### PR DESCRIPTION
🎯 **What:** The fix addresses a potential Cross-Site Scripting (XSS) vulnerability related to `dangerouslySetInnerHTML` rendering.
⚠️ **Risk:** Left unfixed, malicious users or compromised databases could inject malicious scripts or styles into the application, leading to user data theft or UI hijacking.
🛡️ **Solution:** A centralized wrapper around `DOMPurify` (`src/utils/sanitizeHtml.ts`) has been created. It forces a strict HTML profile, removes all `style` tags and attributes, and securely overrides anchor tags (`<a>`) to open in a new tab safely (`rel="noopener noreferrer"`), mitigating reverse tabnapping. Callsites using inline `dangerouslySetInnerHTML` and `DOMPurify` have been refactored to use this new utility.

---
*PR created automatically by Jules for task [192674429290138931](https://jules.google.com/task/192674429290138931) started by @ecc521*