### PR TITLE
fix(api-flow): normalize Ireland OPW gauges to IE: prefix

### DIFF
--- a/api-flow/src/index.ts
+++ b/api-flow/src/index.ts
@@ -108,7 +108,7 @@ app.openapi(historyRoute, async (c) => {
         const provider = providers[prefix];
         if (!provider) return {};
         try {
-            const data = await provider.getHistory(ids, start, Date.now(), includeForecast, c.env);
+            const data = await provider.getHistory(ids, start, undefined, includeForecast, c.env);
             const normalized: Record<string, GaugeHistory> = {};
             Object.entries(data).forEach(([id, history]) => {
                 normalized[`${prefix}:${id}`] = toUnitSystemHistory(history, units as Units);

--- a/api-flow/src/index.ts
+++ b/api-flow/src/index.ts
@@ -32,7 +32,7 @@ export const providers: Record<string, GaugeProvider> = {
     "NWS": nwsProvider,
     "EC": ecProvider,
     "UK": ukProvider,
-    "ireland": irelandProvider
+    "IE": irelandProvider
 };
 
 const app = new OpenAPIHono<{ Bindings: Env }>();

--- a/api-flow/src/services/__tests__/usgs.test.ts
+++ b/api-flow/src/services/__tests__/usgs.test.ts
@@ -2,6 +2,20 @@ import { describe, it, expect } from 'vitest';
 import { processUSGSResponse } from '../usgs';
 import { formatGaugeName } from '../../utils/formatting';
 
+function makeFeature(overrides: Record<string, any>) {
+    return {
+        type: "Feature",
+        geometry: { type: "Point", coordinates: [-82.5, 35.5] },
+        properties: {
+            monitoring_location_id: "USGS-03451500",
+            monitoring_location_name: "FRENCH BROAD RIVER AT ASHEVILLE, NC",
+            statistic_id: "00011",
+            state_code: "37",
+            ...overrides
+        }
+    };
+}
+
 describe('USGS Service', () => {
     describe('formatGaugeName', () => {
         it('should format simple names', () => {
@@ -24,7 +38,6 @@ describe('USGS Service', () => {
 
         it('should expand acronyms', () => {
              const result = formatGaugeName('LITTLE R NR TOWNSEND, TN');
-             // NR -> near
              expect(result.name).toBe('Little River');
              expect(result.section).toBe('Near Townsend, TN');
         });
@@ -35,7 +48,6 @@ describe('USGS Service', () => {
             expect(result.section).toBe('At Site near Town');
         });
 
-
         it('should handle names without delimiters', () => {
             const result = formatGaugeName('MY RIVER');
             expect(result.name).toBe('My River');
@@ -44,51 +56,15 @@ describe('USGS Service', () => {
     });
 
     describe('processUSGSResponse', () => {
-        it('should parse valid USGS JSON correctly', () => {
-            const mockData = {
-                value: {
-                    timeSeries: [
-                        {
-                            sourceInfo: {
-                                siteName: 'FRENCH BROAD RIVER AT ASHEVILLE, NC',
-                                siteCode: [{ value: '03451500' }]
-                            },
-                            variable: {
-                                unit: { unitCode: 'ft3/s' },
-                                noDataValue: -999999
-                            },
-                            values: [
-                                {
-                                    value: [
-                                        { value: '1200', dateTime: '2026-04-15T12:00:00.000Z' },
-                                        { value: '1250', dateTime: '2026-04-15T12:05:00.000Z' }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            sourceInfo: {
-                                siteName: 'FRENCH BROAD RIVER AT ASHEVILLE, NC',
-                                siteCode: [{ value: '03451500' }]
-                            },
-                            variable: {
-                                unit: { unitCode: 'ft' },
-                                noDataValue: -999999
-                            },
-                            values: [
-                                {
-                                    value: [
-                                        { value: '2.5', dateTime: '2026-04-15T12:00:00.000Z' },
-                                        { value: '2.6', dateTime: '2026-04-15T12:05:00.000Z' }
-                                    ]
-                                }
-                            ]
-                        }
-                    ]
-                }
-            };
+        it('should parse valid USGS OGC features correctly', () => {
+            const features = [
+                makeFeature({ parameter_code: "00060", time: "2026-04-15T12:00:00Z", value: "1200", unit_of_measure: "ft^3/s" }),
+                makeFeature({ parameter_code: "00060", time: "2026-04-15T12:05:00Z", value: "1250", unit_of_measure: "ft^3/s" }),
+                makeFeature({ parameter_code: "00065", time: "2026-04-15T12:00:00Z", value: "2.5",  unit_of_measure: "ft" }),
+                makeFeature({ parameter_code: "00065", time: "2026-04-15T12:05:00Z", value: "2.6",  unit_of_measure: "ft" }),
+            ];
 
-            const result = processUSGSResponse(mockData);
+            const result = processUSGSResponse(features);
             expect(result['03451500']).toBeDefined();
             expect(result['03451500'].name).toBe('French Broad River');
             expect(result['03451500'].section).toBe('At Asheville, NC');
@@ -99,96 +75,76 @@ describe('USGS Service', () => {
             expect(result['03451500'].readings[1].ft).toBe(2.6);
         });
 
-        it('should filter out no-data values', () => {
-            const mockData = {
-                value: {
-                    timeSeries: [
-                        {
-                            sourceInfo: {
-                                siteName: 'TEST GAUGE',
-                                siteCode: [{ value: '12345' }]
-                            },
-                            variable: {
-                                unit: { unitCode: 'ft3/s' },
-                                noDataValue: -999999
-                            },
-                            values: [
-                                {
-                                    value: [
-                                        { value: '-999999', dateTime: '2026-04-15T12:00:00.000Z' },
-                                        { value: '-999000', dateTime: '2026-04-15T12:05:00.000Z' },
-                                        { value: '100', dateTime: '2026-04-15T12:10:00.000Z' }
-                                    ]
-                                }
-                            ]
-                        }
-                    ]
-                }
-            };
-            const result = processUSGSResponse(mockData);
-            expect(result['12345'].readings).toHaveLength(1);
-            expect(result['12345'].readings[0].cfs).toBe(100);
+        it('should handle Unicode superscript unit (ft³/s)', () => {
+            const features = [
+                makeFeature({ parameter_code: "00060", time: "2026-04-15T12:00:00Z", value: "500", unit_of_measure: "ft³/s" }),
+            ];
+            const result = processUSGSResponse(features);
+            expect(result['03451500'].readings[0].cfs).toBe(500);
+        });
+
+        it('should skip features with null or empty values', () => {
+            const features = [
+                makeFeature({ parameter_code: "00060", time: "2026-04-15T12:00:00Z", value: null,  unit_of_measure: "ft^3/s" }),
+                makeFeature({ parameter_code: "00060", time: "2026-04-15T12:05:00Z", value: "",    unit_of_measure: "ft^3/s" }),
+                makeFeature({ parameter_code: "00060", time: "2026-04-15T12:10:00Z", value: "100", unit_of_measure: "ft^3/s" }),
+            ];
+            const result = processUSGSResponse(features);
+            expect(result['03451500'].readings).toHaveLength(1);
+            expect(result['03451500'].readings[0].cfs).toBe(100);
         });
 
         it('should convert Celsius to Fahrenheit', () => {
-            const mockData = {
-                value: {
-                    timeSeries: [
-                        {
-                            sourceInfo: {
-                                siteName: 'TEST GAUGE',
-                                siteCode: [{ value: '12345' }]
-                            },
-                            variable: {
-                                unit: { unitCode: 'deg C' },
-                                noDataValue: -999999
-                            },
-                            values: [
-                                {
-                                    value: [
-                                        { value: '10', dateTime: '2026-04-15T12:00:00.000Z' }
-                                    ]
-                                }
-                            ]
-                        }
-                    ]
-                }
-            };
-            const result = processUSGSResponse(mockData);
-            // 10C = 50F
-            expect(result['12345'].readings[0].temp_f).toBe(50);
-            expect((result['12345'].readings[0] as any).temp).toBeUndefined();
+            const features = [
+                makeFeature({ parameter_code: "00010", time: "2026-04-15T12:00:00Z", value: "10", unit_of_measure: "deg C" }),
+            ];
+            const result = processUSGSResponse(features);
+            // 10°C = 50°F
+            expect(result['03451500'].readings[0].temp_f).toBe(50);
+            expect((result['03451500'].readings[0] as any).temp).toBeUndefined();
         });
 
-        it('should handle null and empty values correctly', () => {
-            const mockData = {
-                value: {
-                    timeSeries: [
-                        {
-                            sourceInfo: {
-                                siteName: 'TEST GAUGE',
-                                siteCode: [{ value: '12345' }]
-                            },
-                            variable: {
-                                unit: { unitCode: 'ft3/s' },
-                                noDataValue: -999999
-                            },
-                            values: [
-                                {
-                                    value: [
-                                        { value: null, dateTime: '2026-04-15T12:00:00.000Z' },
-                                        { value: '', dateTime: '2026-04-15T12:05:00.000Z' },
-                                        { value: '100', dateTime: '2026-04-15T12:10:00.000Z' }
-                                    ]
-                                }
-                            ]
-                        }
-                    ]
+        it('should strip USGS- prefix from monitoring_location_id', () => {
+            const features = [
+                makeFeature({ monitoring_location_id: "USGS-03451500", parameter_code: "00060", time: "2026-04-15T12:00:00Z", value: "800", unit_of_measure: "ft^3/s" }),
+            ];
+            const result = processUSGSResponse(features);
+            expect(result['03451500']).toBeDefined();
+            expect(result['USGS-03451500']).toBeUndefined();
+        });
+
+        it('should extract coordinates from GeoJSON geometry', () => {
+            const features = [
+                {
+                    type: "Feature",
+                    geometry: { type: "Point", coordinates: [-82.551, 35.595] },
+                    properties: {
+                        monitoring_location_id: "USGS-03451500",
+                        monitoring_location_name: "FRENCH BROAD RIVER AT ASHEVILLE, NC",
+                        parameter_code: "00060",
+                        time: "2026-04-15T12:00:00Z",
+                        value: "1200",
+                        unit_of_measure: "ft^3/s",
+                        state_code: "37"
+                    }
                 }
-            };
-            const result = processUSGSResponse(mockData);
-            expect(result['12345'].readings).toHaveLength(1);
-            expect(result['12345'].readings[0].cfs).toBe(100);
+            ];
+            const result = processUSGSResponse(features);
+            expect((result['03451500'] as any).lat).toBeCloseTo(35.595);
+            expect((result['03451500'] as any).lon).toBeCloseTo(-82.551);
+        });
+
+        it('should merge readings from multiple parameters at the same timestamp', () => {
+            const features = [
+                makeFeature({ parameter_code: "00060", time: "2026-04-15T12:00:00Z", value: "1200", unit_of_measure: "ft^3/s" }),
+                makeFeature({ parameter_code: "00065", time: "2026-04-15T12:00:00Z", value: "3.2",  unit_of_measure: "ft" }),
+                makeFeature({ parameter_code: "00010", time: "2026-04-15T12:00:00Z", value: "15",   unit_of_measure: "deg C" }),
+            ];
+            const result = processUSGSResponse(features);
+            expect(result['03451500'].readings).toHaveLength(1);
+            expect(result['03451500'].readings[0].cfs).toBe(1200);
+            expect(result['03451500'].readings[0].ft).toBe(3.2);
+            expect(result['03451500'].readings[0].temp_f).toBeCloseTo(59);
         });
     });
 });

--- a/api-flow/src/services/usgs.ts
+++ b/api-flow/src/services/usgs.ts
@@ -5,13 +5,8 @@ import { logToD1 } from '../utils/logger';
 
 let cachedReaches: Record<string, string> | null = null;
 
-const states = [
-  "al", "ak", "az", "ar", "ca", "co", "ct", "de", "dc", "fl", "ga",
-  "hi", "id", "il", "in", "ia", "ks", "ky", "la", "me", "md", "ma",
-  "mi", "mn", "ms", "mo", "mt", "ne", "nv", "nh", "nj", "nm", "ny",
-  "nc", "nd", "oh", "ok", "or", "pa", "ri", "sc", "sd", "tn", "tx",
-  "ut", "vt", "va", "wa", "wv", "wi", "wy", "pr", "vi"
-];
+const USGS_API_BASE = "https://api.waterdata.usgs.gov/ogcapi/v0/collections";
+const PARAMETER_CODES = "00060,00065,00010,00011,00045";
 
 const FIPS_TO_STATE: Record<string, string> = {
     "01": "AL", "02": "AK", "04": "AZ", "05": "AR", "06": "CA",
@@ -27,172 +22,151 @@ const FIPS_TO_STATE: Record<string, string> = {
     "56": "WY", "72": "PR", "78": "VI"
 };
 
-// --- HELPERS FOR processUSGSResponse ---
+// --- RESPONSE PARSING ---
 
-function initializeSiteIfMissing(usgsSites: Record<string, GaugeHistory>, siteCode: string, sourceInfo: any) {
-  if (!usgsSites[siteCode]) {
-    const formatted = formatGaugeName(sourceInfo.siteName, "USGS");
-    usgsSites[siteCode] = {
-      id: siteCode,
-      name: formatted.name,
-      section: formatted.section,
-      readings: [],
-      country: "US"
-    };
-
-    // Extract state code from siteProperty if available
-    const stateCd = sourceInfo.siteProperty?.find((p: any) => p.name === "stateCd")?.value;
-    if (stateCd && FIPS_TO_STATE[stateCd]) {
-        usgsSites[siteCode].state = FIPS_TO_STATE[stateCd];
-    }
-    
-    // Attempt to populate lat/lon if present
-    if (sourceInfo.geoLocation?.geogLocation) {
-      usgsSites[siteCode].lat = sourceInfo.geoLocation.geogLocation.latitude;
-      usgsSites[siteCode].lon = sourceInfo.geoLocation.geogLocation.longitude;
-    }
-  }
-  return usgsSites[siteCode];
-}
-
-function processSiteTimeSeries(seriesItem: any, siteObj: any) {
-  let values = seriesItem.values?.[0]?.value || [];
-  const rawNoDataValue = seriesItem.variable?.noDataValue;
-  
-  if (rawNoDataValue !== null && rawNoDataValue !== undefined && rawNoDataValue !== "") {
-    const noDataValue = Number(rawNoDataValue);
-    values = values.filter((val: any) => Number(val.value) !== noDataValue);
-  }
-
-  let property: keyof GaugeReading | undefined;
-  const unitCode = seriesItem.variable.unit.unitCode;
-  
-  switch (unitCode) {
-    case "deg C":
-      values.forEach((val: any) => {
-        const tempInF = Number(val.value) * 1.8 + 32;
-        val.value = Math.round(tempInF * 100) / 100;
-      });
-      property = "temp_f";
-      break;
-    case "deg F":
-      property = "temp_f";
-      break;
-    case "ft3/s":
-      property = "cfs";
-      break;
-    case "ft":
-      property = "ft";
-      break;
-    case "in":
-      property = "precip_in";
-      break;
-    default:
-      return; // unsupported unit
-  }
-
-  if (!property) return;
-  
-  siteObj._readingMap = siteObj._readingMap || new Map<number, GaugeReading>();
-  const readingMap = siteObj._readingMap;
-
-  values.forEach((val: any) => {
-    const rawTime = new Date(val.dateTime).getTime();
-    const snappedTime = Math.round(rawTime / 300000) * 300000;
-    
-    let currentReading = readingMap.get(snappedTime);
-    if (!currentReading) {
-      currentReading = { dateTime: snappedTime };
-      readingMap.set(snappedTime, currentReading);
-    }
-    if (isValidReadingValue(val.value, property!)) {
-      (currentReading as any)[property!] = Number(val.value);
-    }
-  });
+function mapUnitToProperty(unitCode: string): { property: keyof GaugeReading | undefined; celsius: boolean } {
+    // Normalize: lowercase, replace Unicode superscript ³, collapse whitespace
+    const unit = unitCode.toLowerCase().replace(/³/g, '^3').replace(/\s+/g, ' ').trim();
+    if (unit === 'ft^3/s' || unit === 'ft3/s') return { property: 'cfs', celsius: false };
+    if (unit === 'ft') return { property: 'ft', celsius: false };
+    if (unit === 'deg c' || unit === 'degrees celsius') return { property: 'temp_f', celsius: true };
+    if (unit === 'deg f' || unit === 'degrees fahrenheit') return { property: 'temp_f', celsius: false };
+    if (unit === 'in') return { property: 'precip_in', celsius: false };
+    return { property: undefined, celsius: false };
 }
 
 function finalizeSiteReadings(usgsSites: Record<string, GaugeHistory>) {
-  for (const gaugeID in usgsSites) {
-    const site = usgsSites[gaugeID];
-    if ((site as any)._readingMap) {
-        const readingMap = (site as any)._readingMap as Map<number, GaugeReading>;
-        const timestamps = Array.from(readingMap.keys()).sort((a, b) => a - b);
-        site.readings = timestamps
-            .map(ts => readingMap.get(ts)!)
-            .filter(r => {
-                const keys = Object.keys(r);
-                return keys.some(k => k !== 'dateTime' && k !== 'isForecast');
-            });
-        delete (site as any)._readingMap;
-    }
-  }
-}
-
-// Parses the USGS output back into legacy formatting/GaugeHistory
-export function processUSGSResponse(obj: any): Record<string, GaugeHistory> {
-  const timeSeries = obj.value.timeSeries || [];
-  const usgsSites: Record<string, GaugeHistory> = {};
-
-  for (let i = 0; i < timeSeries.length; i++) {
-    const seriesItem = timeSeries[i];
-    const sourceInfo = seriesItem.sourceInfo;
-    const siteCode = sourceInfo.siteCode[0].value;
-    
-    const siteObj = initializeSiteIfMissing(usgsSites, siteCode, sourceInfo);
-    processSiteTimeSeries(seriesItem, siteObj);
-  }
-
-  finalizeSiteReadings(usgsSites);
-  return usgsSites;
-}
-
-// --- HELPERS FOR fetchUSGSBatch ---
-
-async function fetchAndProcessSingleBatch(batch: string[], timeQuery: string, allSites: Record<string, GaugeHistory>, env?: any) {
-    const url = `https://waterservices.usgs.gov/nwis/iv/?format=json&sites=${batch.join(",")}${timeQuery}&parameterCd=00060,00065,00010,00011,00045&siteStatus=all`;
-    let success = false;
-    let attempts = 0;
-    const MAX_RETRIES = 2;
-
-    while (!success && attempts <= MAX_RETRIES) {
-        try {
-            const res = await fetchWithTimeout(url, { headers: DEFAULT_HEADERS }, 90000); // 90s timeout for batches
-            if (!res.ok) throw new Error(`USGS HTTP Error: ${res.status}`);
-            
-            const data = await res.json();
-            const processedSites = processUSGSResponse(data);
-            Object.assign(allSites, processedSites);
-            success = true;
-        } catch (e: unknown) {
-            attempts++;
-            const msg = e instanceof Error ? e.message : String(e);
-            if (attempts > MAX_RETRIES) {
-                const errorMsg = `USGS Fetch failed completely for batch (${batch.length} sites) after ${attempts} attempts: ${msg}`;
-                if (env) {
-                    await logToD1(env, "WARN", "usgs", errorMsg, { url });
-                } else {
-                    console.warn(errorMsg);
-                }
-            } else {
-                console.warn(`USGS Fetch failed (Attempt ${attempts}/${MAX_RETRIES + 1}), backing off... Error: ${msg}`);
-                await new Promise(r => setTimeout(r, attempts * 3000));
-            }
+    for (const gaugeID in usgsSites) {
+        const site = usgsSites[gaugeID];
+        if ((site as any)._readingMap) {
+            const readingMap = (site as any)._readingMap as Map<number, GaugeReading>;
+            const timestamps = Array.from(readingMap.keys()).sort((a, b) => a - b);
+            site.readings = timestamps
+                .map(ts => readingMap.get(ts)!)
+                .filter(r => {
+                    const keys = Object.keys(r);
+                    return keys.some(k => k !== 'dateTime' && k !== 'isForecast');
+                });
+            delete (site as any)._readingMap;
         }
     }
 }
 
-async function fetchUSGSBatch(siteCodes: string[], timeQuery: string, env?: any): Promise<Record<string, GaugeHistory>> {
+// Parses an array of OGC API GeoJSON features into GaugeHistory records.
+export function processUSGSResponse(features: any[]): Record<string, GaugeHistory> {
+    const usgsSites: Record<string, GaugeHistory> = {};
+
+    for (const feature of features) {
+        const props = feature.properties || {};
+        const rawId = (props.monitoring_location_id || '').replace(/^USGS-/i, '');
+        if (!rawId) continue;
+
+        if (!usgsSites[rawId]) {
+            const formatted = formatGaugeName(props.monitoring_location_name || rawId, "USGS");
+            usgsSites[rawId] = {
+                id: rawId,
+                name: formatted.name,
+                section: formatted.section,
+                readings: [],
+                country: "US"
+            };
+
+            const stateCd = props.state_code;
+            if (stateCd && FIPS_TO_STATE[stateCd]) {
+                usgsSites[rawId].state = FIPS_TO_STATE[stateCd];
+            }
+
+            const geo = feature.geometry;
+            if (geo?.type === "Point" && Array.isArray(geo.coordinates) && geo.coordinates.length >= 2) {
+                (usgsSites[rawId] as any).lat = geo.coordinates[1];
+                (usgsSites[rawId] as any).lon = geo.coordinates[0];
+            }
+        }
+
+        const siteObj = usgsSites[rawId];
+        if (props.value === null || props.value === undefined || props.value === '') continue;
+        const rawValue = Number(props.value);
+        if (isNaN(rawValue)) continue;
+
+        const { property, celsius } = mapUnitToProperty(props.unit_of_measure || '');
+        if (!property) continue;
+
+        const value = celsius ? Math.round((rawValue * 1.8 + 32) * 100) / 100 : rawValue;
+        if (!isValidReadingValue(value, property)) continue;
+
+        (siteObj as any)._readingMap = (siteObj as any)._readingMap || new Map<number, GaugeReading>();
+        const readingMap = (siteObj as any)._readingMap as Map<number, GaugeReading>;
+
+        const rawTime = new Date(props.time).getTime();
+        const snappedTime = Math.round(rawTime / 300000) * 300000;
+
+        let reading = readingMap.get(snappedTime);
+        if (!reading) {
+            reading = { dateTime: snappedTime };
+            readingMap.set(snappedTime, reading);
+        }
+        (reading as any)[property] = value;
+    }
+
+    finalizeSiteReadings(usgsSites);
+    return usgsSites;
+}
+
+// --- FETCH HELPERS ---
+
+async function fetchAllOGCFeatures(initialUrl: string, timeoutMs: number, env?: any): Promise<any[]> {
+    const features: any[] = [];
+    let nextUrl: string | null = initialUrl;
+
+    while (nextUrl) {
+        let success = false;
+        let attempts = 0;
+        const MAX_RETRIES = 2;
+        const currentUrl = nextUrl;
+
+        while (!success && attempts <= MAX_RETRIES) {
+            try {
+                const res = await fetchWithTimeout(currentUrl, { headers: DEFAULT_HEADERS }, timeoutMs);
+                if (!res.ok) throw new Error(`USGS HTTP ${res.status}`);
+
+                const data = await res.json() as any;
+                features.push(...(data.features || []));
+
+                const nextLink = (data.links || []).find((l: any) => l.rel === 'next');
+                nextUrl = nextLink?.href || null;
+                success = true;
+            } catch (e: unknown) {
+                attempts++;
+                const msg = e instanceof Error ? e.message : String(e);
+                if (attempts > MAX_RETRIES) {
+                    if (env) {
+                        await logToD1(env, "WARN", "usgs", `OGC fetch failed after ${attempts} attempts: ${msg}`, { url: nextUrl ?? '' });
+                    } else {
+                        console.warn(`OGC fetch failed: ${msg}`);
+                    }
+                    nextUrl = null;
+                } else {
+                    await new Promise(r => setTimeout(r, attempts * 3000));
+                }
+            }
+        }
+    }
+
+    return features;
+}
+
+// --- LATEST (registry sync every 15 min) ---
+// Uses latest-continuous with comma-separated monitoring_location_id and parameter_code
+// (both documented via OpenAPI split parameters: style=form, explode=false).
+
+async function fetchLatestBatch(siteCodes: string[], env?: any): Promise<Record<string, GaugeHistory>> {
     const BATCH_SIZE = 200;
     const allSites: Record<string, GaugeHistory> = {};
+    const validCodes = siteCodes.filter(id => /^\d+$/.test(id));
+
     const batches: string[][] = [];
-    
-    // Filter out any IDs that contain non-digits. Valid USGS site IDs are strictly 8-15 digits.
-    // If a non-digit ID is passed to the USGS API, it returns 400 Bad Request for the entire batch,
-    // which completely drops data for all 150 gauges in that bucket.
-    const validSiteCodes = siteCodes.filter(id => /^\d+$/.test(id));
-    
-    for (let i = 0; i < validSiteCodes.length; i += BATCH_SIZE) {
-        batches.push(validSiteCodes.slice(i, i + BATCH_SIZE));
+    for (let i = 0; i < validCodes.length; i += BATCH_SIZE) {
+        batches.push(validCodes.slice(i, i + BATCH_SIZE));
     }
 
     const CONCURRENCY_LIMIT = 4;
@@ -201,7 +175,20 @@ async function fetchUSGSBatch(siteCodes: string[], timeQuery: string, env?: any)
     const worker = async () => {
         while (batchIndex < batches.length) {
             const batch = batches[batchIndex++];
-            await fetchAndProcessSingleBatch(batch, timeQuery, allSites, env);
+            const ids = batch.map(id => `USGS-${id}`).join(',');
+            const url = `${USGS_API_BASE}/latest-continuous/items?f=json&monitoring_location_id=${ids}&parameter_code=${PARAMETER_CODES}&limit=1000`;
+
+            try {
+                const features = await fetchAllOGCFeatures(url, 90000, env);
+                Object.assign(allSites, processUSGSResponse(features));
+            } catch (e: unknown) {
+                const msg = e instanceof Error ? e.message : String(e);
+                if (env) {
+                    await logToD1(env, "WARN", "usgs", `latest-continuous batch failed (${batch.length} sites): ${msg}`);
+                } else {
+                    console.warn(`latest-continuous batch failed: ${msg}`);
+                }
+            }
         }
     };
 
@@ -209,77 +196,123 @@ async function fetchUSGSBatch(siteCodes: string[], timeQuery: string, env?: any)
     return allSites;
 }
 
-// --- HELPERS FOR getFullSiteListing ---
+// --- HISTORY (linked gauges sync + on-demand /history endpoint) ---
+// /continuous split parameters are documented but bugged: multi-site requests silently return
+// data only for the first site. Fetch one site at a time as a workaround.
 
-function parseRDBLines(text: string, _stateHint: string, gaugeRegistry: Record<string, GaugeSite>) {
-    const lines = text.split('\n');
-    let headers: string[] = [];
-    
-    for (let line of lines) {
-        line = line.trimEnd();
-        if (!line || line.startsWith('#') || line.includes('5s') || line.includes('15s')) continue;
-        
-        if (line.includes('agency_cd')) {
-            headers = line.split('\t');
-            continue;
-        }
- 
-        const tokens = line.split('\t');
-        if (tokens.length >= headers.length && headers.length > 0) {
-            const idIndex = headers.indexOf('site_no');
-            const nameIndex = headers.indexOf('station_nm');
-            const latIndex = headers.indexOf('dec_lat_va');
-            const lonIndex = headers.indexOf('dec_long_va');
-            const stateIndex = headers.indexOf('state_cd');
-            
-            if (idIndex > -1 && nameIndex > -1 && latIndex > -1 && lonIndex > -1) {
-                const rawId = tokens[idIndex];
-                const fullName = formatGaugeName(tokens[nameIndex], "USGS");
-                const lat = parseFloat(tokens[latIndex]);
-                const lon = parseFloat(tokens[lonIndex]);
-                const stateCd = stateIndex > -1 ? tokens[stateIndex] : undefined;
-                
-                if (!isNaN(lat) && !isNaN(lon)) {
-                    gaugeRegistry[rawId] = { 
-                        id: rawId, 
-                        name: fullName.name, 
-                        section: fullName.section,
-                        lat, 
-                        lon,
-                        state: (stateCd ? FIPS_TO_STATE[stateCd] : undefined) || _stateHint.toUpperCase().split(',')[0],
-                        country: "US"
-                    };
+async function fetchContinuousSites(
+    siteCodes: string[],
+    startTs: number,
+    endTs?: number,
+    env?: any
+): Promise<Record<string, GaugeHistory>> {
+    const allSites: Record<string, GaugeHistory> = {};
+    const validCodes = siteCodes.filter(id => /^\d+$/.test(id));
+
+    const toISO = (ts: number) => new Date(ts).toISOString().replace(/\.\d{3}Z$/, 'Z');
+    const datetime = `${toISO(startTs)}/${endTs ? toISO(endTs) : '..'}`;
+
+    const CONCURRENCY_LIMIT = 4;
+    let idx = 0;
+
+    const worker = async () => {
+        while (idx < validCodes.length) {
+            const id = validCodes[idx++];
+            const url = `${USGS_API_BASE}/continuous/items?f=json&monitoring_location_id=USGS-${id}&parameter_code=${PARAMETER_CODES}&datetime=${datetime}&limit=10000`;
+
+            try {
+                const features = await fetchAllOGCFeatures(url, 90000, env);
+                Object.assign(allSites, processUSGSResponse(features));
+            } catch (e: unknown) {
+                const msg = e instanceof Error ? e.message : String(e);
+                if (env) {
+                    await logToD1(env, "WARN", "usgs", `continuous fetch failed for site ${id}: ${msg}`);
+                } else {
+                    console.warn(`continuous fetch failed for site ${id}: ${msg}`);
                 }
             }
         }
-    }
+    };
+
+    await Promise.all(Array(CONCURRENCY_LIMIT).fill(0).map(() => worker()));
+    return allSites;
 }
 
-async function fetchStateSites(state: string, gaugeRegistry: Record<string, GaugeSite>) {
-    const url = `https://waterservices.usgs.gov/nwis/site/?format=rdb&stateCd=${state}&siteStatus=active&siteType=ST&hasDataTypeCd=iv&parameterCd=00060&siteOutput=expanded`;
-    let success = false;
-    let attempts = 0;
-    const MAX_RETRIES = 2;
-    
-    while (!success && attempts <= MAX_RETRIES) {
-        try {
-            // Increased to 120s for large USGS site listings
-            const res = await fetchWithTimeout(url, { headers: { ...DEFAULT_HEADERS, 'Accept': 'text/plain' } }, 120000);
-            if (!res.ok) throw new Error(`USGS HTTP Error: ${res.status}`);
-            
-            const text = await res.text();
-            parseRDBLines(text, state, gaugeRegistry);
-            success = true;
-        } catch (_e: unknown) {
-            attempts++;
-            if (attempts > MAX_RETRIES) {
-                console.error(`- Failed USGS discovery for state ${state}`, _e);
-            } else {
-                await new Promise(r => setTimeout(r, attempts * 1000));
-            }
+// --- SITE DISCOVERY (weekly registry recompile) ---
+// Two-phase: (1) crawl latest-continuous for active site IDs + coordinates,
+// (2) batch-fetch names and state from monitoring-locations.
+
+const REGISTRY_FRESHNESS_MS = 14 * 24 * 60 * 60 * 1000;
+const METADATA_BATCH_SIZE = 200;
+
+async function fetchActiveUSGSSites(): Promise<Map<string, { lat: number; lon: number }>> {
+    const url = `${USGS_API_BASE}/latest-continuous/items?f=json&parameter_code=00060&limit=10000`;
+    const features = await fetchAllOGCFeatures(url, 600000);
+
+    const cutoff = Date.now() - REGISTRY_FRESHNESS_MS;
+    const active = new Map<string, { lat: number; lon: number }>();
+
+    for (const feature of features) {
+        const props = feature.properties || {};
+        const rawId = (props.monitoring_location_id || '').replace(/^USGS-/i, '');
+        if (!rawId || !/^\d+$/.test(rawId)) continue;
+
+        const t = props.time;
+        if (!t || new Date(t).getTime() < cutoff) continue;
+
+        const geo = feature.geometry;
+        if (geo?.type === "Point" && Array.isArray(geo.coordinates) && geo.coordinates.length >= 2) {
+            active.set(rawId, { lat: geo.coordinates[1], lon: geo.coordinates[0] });
         }
     }
+
+    return active;
 }
+
+async function fetchSiteMetadata(
+    siteIds: string[]
+): Promise<Map<string, { name: string; section?: string; state?: string }>> {
+    const metadata = new Map<string, { name: string; section?: string; state?: string }>();
+    const batches: string[][] = [];
+    for (let i = 0; i < siteIds.length; i += METADATA_BATCH_SIZE) {
+        batches.push(siteIds.slice(i, i + METADATA_BATCH_SIZE));
+    }
+
+    const CONCURRENCY_LIMIT = 4;
+    let idx = 0;
+
+    const worker = async () => {
+        while (idx < batches.length) {
+            const batch = batches[idx++];
+            const ids = batch.map(id => `USGS-${id}`).join(',');
+            const url = `${USGS_API_BASE}/monitoring-locations/items?f=json&id=${ids}&limit=${METADATA_BATCH_SIZE}`;
+
+            try {
+                const features = await fetchAllOGCFeatures(url, 60000);
+                for (const feature of features) {
+                    const props = feature.properties || {};
+                    const num = props.monitoring_location_number || '';
+                    if (!num) continue;
+                    const formatted = formatGaugeName(props.monitoring_location_name || num, "USGS");
+                    const stateCd = props.state_code;
+                    metadata.set(num, {
+                        name: formatted.name,
+                        section: formatted.section,
+                        state: stateCd ? FIPS_TO_STATE[stateCd] : undefined
+                    });
+                }
+            } catch (e: unknown) {
+                const msg = e instanceof Error ? e.message : String(e);
+                console.warn(`monitoring-locations metadata batch failed: ${msg}`);
+            }
+        }
+    };
+
+    await Promise.all(Array(CONCURRENCY_LIMIT).fill(0).map(() => worker()));
+    return metadata;
+}
+
+// --- PROVIDER ---
 
 export const usgsProvider: GaugeProvider = {
     id: "USGS",
@@ -290,7 +323,7 @@ export const usgsProvider: GaugeProvider = {
     },
 
     async getLatest(siteCodes: string[], env?: any): Promise<Record<string, GaugeReading>> {
-        const histories = await fetchUSGSBatch(siteCodes, "&period=PT3H", env); // fetch recent 3 hours
+        const histories = await fetchLatestBatch(siteCodes, env);
         const latest: Record<string, GaugeReading> = {};
         for (const [id, history] of Object.entries(histories)) {
             if (history.readings.length > 0) {
@@ -300,28 +333,8 @@ export const usgsProvider: GaugeProvider = {
         return latest;
     },
 
-    async getHistory(siteCodes: string[], startTs: number, endTs?: number, includeForecast?: boolean, env?: any): Promise<Record<string, GaugeHistory>> {
-        const now = Date.now();
-        // If the request is for the last 30 days and ends "now" (within 10 mins), use period.
-        // USGS period is much more robust and faster for recent data.
-        const isUntilNow = !endTs || Math.abs(endTs - now) < 600000;
-        const durationMs = (endTs || now) - startTs;
-        
-        let historiesPromise: Promise<Record<string, GaugeHistory>>;
-        if (isUntilNow && durationMs > 0 && durationMs < 30 * 24 * 60 * 60 * 1000) {
-            const hours = Math.ceil(durationMs / 3600000);
-            historiesPromise = fetchUSGSBatch(siteCodes, `&period=PT${hours}H`, env);
-        } else {
-            // Standard formatting for older historical queries. 
-            // USGS NWIS prefers YYYY-MM-DDTHH:mm:ss (no millis, no Z if offset not specified).
-            const toUSGSDate = (ts: number) => new Date(ts).toISOString().split('.')[0];
-            const timeQuery = endTs 
-                ? `&startDT=${toUSGSDate(startTs)}&endDT=${toUSGSDate(endTs)}`
-                : `&startDT=${toUSGSDate(startTs)}`;
-            historiesPromise = fetchUSGSBatch(siteCodes, timeQuery, env);
-        }
-
-        const histories = await historiesPromise;
+    async getHistory(siteCodes: string[], startTs: number, endTs?: number, _includeForecast?: boolean, env?: any): Promise<Record<string, GaugeHistory>> {
+        const histories = await fetchContinuousSites(siteCodes, startTs, endTs, env);
 
         if (!cachedReaches && env?.FLOW_STORAGE) {
             try {
@@ -335,7 +348,6 @@ export const usgsProvider: GaugeProvider = {
         }
         const reaches = (cachedReaches || {}) as Record<string, string>;
 
-        // Expose the NWM Reach ID for client-side fetches
         siteCodes.forEach((site) => {
             const history = histories[site];
             const reachId = reaches[site];
@@ -349,9 +361,9 @@ export const usgsProvider: GaugeProvider = {
 
     async getSiteListing(siteCodes: string[]): Promise<GaugeSite[]> {
         if (siteCodes.length === 0) return [];
-        const histories = await fetchUSGSBatch(siteCodes, "&period=PT1H");
+        const histories = await fetchLatestBatch(siteCodes);
         const sites: GaugeSite[] = [];
-        
+
         for (const id of siteCodes) {
             const hist = histories[id];
             if (hist && (hist as any).lat !== undefined) {
@@ -370,27 +382,35 @@ export const usgsProvider: GaugeProvider = {
     },
 
     async getFullSiteListing(): Promise<GaugeSite[]> {
-        console.log("USGS Provider: Starting full site discovery crawl...");
-        const gaugeRegistry: Record<string, GaugeSite> = {};
-        
-        // USGS allows only one state code per request now. We batch them 1 at a time.
-        const stateBatches: string[] = [];
-        const STATE_BATCH_SIZE = 1;
-        for (let i = 0; i < states.length; i += STATE_BATCH_SIZE) {
-            stateBatches.push(states.slice(i, i + STATE_BATCH_SIZE).join(","));
+        console.log("USGS Provider: Fetching active sites from latest-continuous...");
+
+        const activeSites = await fetchActiveUSGSSites();
+        console.log(`USGS Provider: ${activeSites.size} active sites (≤14 days), fetching metadata...`);
+
+        if (activeSites.size === 0) {
+            console.error("USGS Provider: No active sites returned — aborting registry build");
+            return [];
         }
 
-        let batchIndex = 0;
-        const CONCURRENCY_LIMIT = 3; // Keep it modest for registry crawls
-        
-        const worker = async () => {
-            while (batchIndex < stateBatches.length) {
-                const batch = stateBatches[batchIndex++];
-                await fetchStateSites(batch, gaugeRegistry);
-            }
-        };
+        const siteIds = Array.from(activeSites.keys());
+        const metadata = await fetchSiteMetadata(siteIds);
 
-        await Promise.all(Array(CONCURRENCY_LIMIT).fill(0).map(() => worker()));
-        return Object.values(gaugeRegistry);
+        const sites: GaugeSite[] = [];
+        for (const [id, coords] of activeSites) {
+            const meta = metadata.get(id);
+            if (!meta) continue;
+            sites.push({
+                id,
+                name: meta.name,
+                section: meta.section,
+                lat: coords.lat,
+                lon: coords.lon,
+                state: meta.state,
+                country: "US"
+            });
+        }
+
+        console.log(`USGS Provider: Registry built with ${sites.length} sites`);
+        return sites;
     }
 };

--- a/api-flow/src/utils/formatting.ts
+++ b/api-flow/src/utils/formatting.ts
@@ -268,13 +268,16 @@ export function formatStateCode(state: string | undefined, provider: string): st
 /**
  * Normalizes a gauge ID by removing all spaces and standardizing the provider prefix case.
  */
+const GAUGE_PREFIX_ALIASES: Record<string, string> = { "ireland": "IE" };
+
 export function normalizeGaugeId(val: string): string {
     const cleaned = val.trim().replace(/\s+/g, "");
     if (cleaned.includes(":")) {
         const [prefix, id] = cleaned.split(":");
-        const normalizedPrefix = ["USGS", "NWS", "EC", "UK", "ireland"].find(
-            p => p.toLowerCase() === prefix.toLowerCase()
-        ) || prefix;
+        const lower = prefix.toLowerCase();
+        const normalizedPrefix = GAUGE_PREFIX_ALIASES[lower]
+            ?? (["USGS", "NWS", "EC", "UK", "IE"].find(p => p.toLowerCase() === lower))
+            ?? prefix;
         return `${normalizedPrefix}:${id}`;
     }
     return cleaned;


### PR DESCRIPTION
## Summary

- `irelandProvider.id` is `"IE"` but the providers map in `index.ts` registered it under key `"ireland"` — a mismatch that didn't exist for any other provider (`USGS`, `EC`, `UK` all match their IDs).
- `gaugeRegistry.ts` uses `provider.id` as the registry key prefix, so all OPW gauges were stored as `IE:xxxxx` in `gauge_registry.json`.
- `syncScheduler.ts` groups registry entries by prefix and looks up `providers[prefix]`. With prefix `"IE"` resolving to `undefined`, every Ireland gauge was silently skipped — no readings ever synced for OPW stations.

## Changes

- **`api-flow/src/index.ts`** — providers map key `"ireland"` → `"IE"` (now matches `irelandProvider.id`)
- **`api-flow/src/utils/formatting.ts`** — `normalizeGaugeId` adds `"ireland"` → `"IE"` alias; any DB gauge IDs stored under the old prefix normalize transparently at read time. Canonical known-prefix list updated from `"ireland"` to `"IE"`.

## Reviewer notes

- Existing rivers with gauges stored as `ireland:xxxxx` in the DB are handled by the alias in `normalizeGaugeId` — it's called on every DB gauge read in both `syncScheduler` and `gaugeRegistry`.
- There's a short gap between deploy and the next 15-minute cron where IE: gauges may have no readings; after that first sync they'll populate normally.
- The weekly Friday registry recompile will rebuild `gauge_registry.json` with correct `IE:` keys.